### PR TITLE
Tweaked define: EXPORT -> xlEXPORT

### DIFF
--- a/ext/ext.c
+++ b/ext/ext.c
@@ -13,15 +13,15 @@
 
 #include "xlisp.h"
 
-#ifndef EXPORT
-#define EXPORT __declspec(dllexport)
+#ifndef xlEXPORT
+#define xlEXPORT __declspec(dllexport)
 #endif
 
 /* prototypes */
 static xlValue myadd(void);
 
 /* initialize - the dll initialization function */
-EXPORT int initialize(void)
+xlEXPORT int initialize(void)
 {
     xlSubr("MY-ADD",myadd);
     return TRUE;


### PR DESCRIPTION
When I tried to build an extension, I ran into trouble on MacOS. Looking at your header file, I think that you meant to use "xlEXPORT" rather than "EXPORT".