### PR TITLE
Fix copy-list crawling on pairlis

### DIFF
--- a/doc/xlisp.md
+++ b/doc/xlisp.md
@@ -789,10 +789,9 @@ Compute the length of a list.
 Creates pairs from corresponding elements of keys and data and pushes these onto
 alist.
 
-For instance:
+For instance: ` (pairlis '(x y) '(1 2) '((z . 3))) => ((x . 1) (y . 2) (z . 3)) `
 
- ```lisp 
- (pairlis '(x y) '(1 2) '((z . 3))) => ((x . 1) (y . 2) (z . 3))
+```lisp
  (COPY-LIST list)
 ```
 Makes a top level copy of the list.


### PR DESCRIPTION
Example using `pairlis` merged with the following function declaration, if you just split the blocks, it is also not very clear, imho. So I suggest doing an example inside the line.